### PR TITLE
S3 filter timebucket

### DIFF
--- a/impresso_commons/path/path_s3.py
+++ b/impresso_commons/path/path_s3.py
@@ -221,7 +221,10 @@ def s3_filter_archives(bucket_name, config, suffix=".jsonl.bz2"):
     """
     Iterate over bucket and filter according to config and suffix.
     Config is a dict where k= newspaper acronym and v = array of 2 years, considered as time interval.
-    Example: config = { "GDL" : [1960, 1970], "JDG": []}. Empty array means no filter, all years.
+    Example: config = { "GDL" : [1960, 1970], => will take all years in interval
+                        "JDG": [], => Empty array means no filter, all years.
+                        "GDL": [1798, 1999, 10] => take each 10th item within sequence of years 
+                        }.
     :param bucket_name: the name of the bucket
     :type bucket_name: str
     :param config: newspaper/years to consider

--- a/impresso_commons/path/path_s3.py
+++ b/impresso_commons/path/path_s3.py
@@ -232,15 +232,20 @@ def s3_filter_archives(bucket_name, config, suffix=".jsonl.bz2"):
     """
     filtered_keys = []
     accept_key = lambda k: True
-    keynames = ["allyears"]
+    keynames = ["allyears"]  # todo
 
     # generate keynames from config (e.g. 'GDL/GDL-1950.jsonl.bz2')
     for np in config:
         if config[np]:
-            keynames = [
+            tmp = [
                 np + "/" + np + "-" + str(item) + suffix
                 for item in range(config[np][0], config[np][1])
             ]
+            if len(config[np]) == 2:
+                keynames = tmp
+            elif len(config[np]) == 3:
+                keynames = tmp[::config[np][2]]
+
             accept_key = lambda k: k in keynames
 
         # retrieving keys

--- a/tests/test_path_s3.py
+++ b/tests/test_path_s3.py
@@ -35,3 +35,11 @@ def test_s3_filter_archives():
     assert keys is not None
     assert len(keys) == 9
 
+
+def test_s3_filter_archives_timebucket():
+    config = {"GDL": [1798, 1999, 10]}
+    b = get_bucket("canonical-rebuilt", create=False)
+    keys = s3_filter_archives(b.name, config=config)
+    assert keys is not None
+    assert len(keys) == 20
+


### PR DESCRIPTION
Added the possibility to slice at every _n_ item in func `s3_iter_archives`:
param `"GDL": [1798, 1999, 10]` will retrieve 1798, 1808, 1818, etc.